### PR TITLE
feat: support static build with tls enabled and linux packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ mosquitto*.tar.gz
 mosquitto*/
 zig-out/
 .zig-cache/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,95 @@
 # zig build for mosquitto
 
-Cross compile mosquitto using zig build.
+Cross compile mosquitto using zig build (tested with ziglang 0.14.0).
 
 - produce static executables
-- no support for TLS
-- bridge disabled
+- support for TLS (with an option to disable it if it is not needed)
+- bridge enabled
+- no websocket support
+- no systemd support (e.g. SDNotify isn't enabled)
+
+## Build Pre-requisites
+
+* ziglang 0.14.0
+* [nfpm](https://nfpm.goreleaser.com/) (to build the linux packages)
+* wget (used to download the mosquitto source code)
+
+## Building
+
+1. Clone the project
+
+    ```sh
+    git clone https://github.com/thin-edge/zig-mosquitto
+    cd zig-mosquitto
+    ```
+
+2. Checkout/download the mosquitto source code
+
+    ```sh
+    just checkout-mosquitto
+    ```
+
+3. Build all targets
+
+    ```sh
+    just build-all
+    ```
+
+    If you don't want to include TLS, then you can run:
+
+    ```sh
+    just build-notls-all
+    ```
+
+4. Use the build linux packages under the `dist/` folder
+
+    ```sh
+    ls -l dist/
+
+    # Using DNF (Fedora, RHEL, AmazonLinux)
+    dnf install tedge-mosquitto*.rpm
+
+    # Using Debian/Ubuntu
+    apt-get install tedge-mosquitto*.deb
+    ```
+
+### Building a single target
+
+If you don't want to build for all of the targets, then you can build using
+
+The compiled `mosquitto` binary will be created under `./zig-out/mosquitto`, however it will only be the binary from the last build.
+
+**With TLS**
+
+```sh
+just build x86_64-linux-musl amd64
+
+just build aarch64-linux-musl arm64
+
+just build arm-linux-musleabihf arm7
+
+just build arm-linux-musleabi arm5
+
+just build riscv64-linux-musl riscv64
+```
+
+**Without TLS**
+
+```sh
+just build-notls x86_64-linux-musl amd64
+
+just build-notls aarch64-linux-musl arm64
+
+just build-notls arm-linux-musleabihf arm7
+
+just build-notls arm-linux-musleabi arm5
+
+just build-notls riscv64-linux-musl riscv64
+```
 
 ```shell
 # Clone: mainly a build.zig file
-$ git clone https://github.com/didier-wenzek/zig-mosquitto
+$ git clone https://github.com/thin-edge/zig-mosquitto
 $ cd zig-mosquitto
 
 # The build expect a mosquitto sub-directory with mosquitto sources 
@@ -24,7 +105,9 @@ $ file zig-out/bin/mosquitto
 zig-out/bin/mosquitto: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, stripped
 ```
 
-TODO:
+## TODO
 
-- Mosquitto version should not be hardcoded
-- [Build for multiple targets to make a release](https://ziglang.org/learn/build-system/#build-for-multiple-targets-to-make-a-release)
+The following items are still yet to be addressed/fixed:
+
+* [ ] Mosquitto version should not be hardcoded
+* [ ] Support for other init systems like OpenRC, SysVInit, s6-overlay

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,0 +1,17 @@
+.{
+    .name = .mosquitto,
+    .version = "2.0.18",
+    .fingerprint = 0xedaa03191382deac,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+    .dependencies = .{
+        .openssl = .{
+            .url = "https://github.com/dzfrias/openssl-zig/archive/refs/heads/main.tar.gz",
+            .hash = "openssl-3.4.0-AAAAAJbeAABDKzRsuNqkIz475RzzA6y5o1R-LoEZumHo",
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -1,0 +1,64 @@
+set dotenv-load
+
+# package name
+PACKAGE_NAME := env("PACKAGE_NAME", "tedge-mosquitto")
+
+# package version
+VERSION := env("VERSION", "2.0.18")
+
+# package version release suffix
+VERSION_RELEASE := env("VERSION_RELEASE", "6")
+
+# ziglang build options to control different user options
+BUILD_OPTIONS := env("BUILD_OPTIONS", "")
+
+# ziglang target triple
+TARGET := env("TARGET", "x86_64-linux-musl")
+
+# nfpm package architecture, this differs from the ziglang target triple
+# as packaging generally have their own naming convention, so nfpm needs
+# to know how to translate these names to deb, rpm, apk etc.
+PACKAGE_TARGET := env("TARGET", "amd64")
+
+# checkout the mosquitto source code
+checkout-mosquitto version=VERSION:
+    wget https://mosquitto.org/files/source/mosquitto-{{version}}.tar.gz
+    tar -xzf mosquitto-{{version}}.tar.gz
+    ln -sf mosquitto-{{version}} mosquitto
+    rm -f mosquitto-{{version}}.tar.gz
+
+# build the binary without tls
+build-notls target=TARGET package_arch=PACKAGE_TARGET:
+    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} {{BUILD_OPTIONS}}
+    mkdir -p dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}-notls" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p rpm -f ./packaging/nfpm.yaml -t dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}-notls" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p apk -f ./packaging/nfpm.yaml -t dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}-notls" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p deb -f ./packaging/nfpm.yaml -t dist/
+
+# build the binary with tls enabled (default)
+build target=TARGET package_arch=PACKAGE_TARGET:
+    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} -DWITH_TLS=true {{BUILD_OPTIONS}}
+    mkdir -p dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p rpm -f ./packaging/nfpm.yaml -t dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p apk -f ./packaging/nfpm.yaml -t dist/
+    PACKAGE_NAME="{{PACKAGE_NAME}}" VERSION_RELEASE={{VERSION_RELEASE}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p deb -f ./packaging/nfpm.yaml -t dist/
+
+# build all targets without tls
+build-notls-all:
+    just build-notls x86_64-linux-musl amd64
+    just build-notls aarch64-linux-musl arm64
+    just build-notls arm-linux-musleabihf arm7
+    just build-notls arm-linux-musleabi arm5
+    just build-notls riscv64-linux-musl riscv64
+
+# build all targets with tls enabled
+build-all:
+    just build x86_64-linux-musl amd64
+    just build aarch64-linux-musl arm64
+    just build arm-linux-musleabihf arm7
+    just build arm-linux-musleabi arm5
+    just build riscv64-linux-musl riscv64
+
+# clean the distribution folders
+clean:
+    rm -rf dist/

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@ PACKAGE_NAME := env("PACKAGE_NAME", "tedge-mosquitto")
 VERSION := env("VERSION", "2.0.18")
 
 # package version release suffix
-VERSION_RELEASE := env("VERSION_RELEASE", "6")
+VERSION_RELEASE := env("VERSION_RELEASE", "1")
 
 # ziglang build options to control different user options
 BUILD_OPTIONS := env("BUILD_OPTIONS", "")

--- a/packaging/conf/ca_certificates/README
+++ b/packaging/conf/ca_certificates/README
@@ -1,0 +1,1 @@
+Place your SSL/TLS Certificate Authority certificates in this directory.

--- a/packaging/conf/certs/README
+++ b/packaging/conf/certs/README
@@ -1,0 +1,3 @@
+Place your SSL/TLS server keys and certificates in this directory.
+
+This directory should only be readable by the mosquitto user.

--- a/packaging/conf/conf.d/README
+++ b/packaging/conf/conf.d/README
@@ -1,0 +1,2 @@
+Any files placed in this directory that have a .conf ending will be loaded as
+config files by the broker. Use this to make your local config.

--- a/packaging/conf/mosquitto.conf
+++ b/packaging/conf/mosquitto.conf
@@ -1,0 +1,7 @@
+persistence true
+persistence_location /var/lib/mosquitto/
+log_dest syslog
+
+max_inflight_messages 200
+
+include_dir /etc/mosquitto/conf.d

--- a/packaging/nfpm.yaml
+++ b/packaging/nfpm.yaml
@@ -1,0 +1,88 @@
+# yaml-language-server: $schema=https://nfpm.goreleaser.com/static/schema.json
+---
+name: ${PACKAGE_NAME}
+arch: ${ARCH}
+platform: linux
+
+# Version. (required)
+# This will expand any env var you set in the field, e.g. version: ${SEMVER}
+# Some package managers, like deb, require the version to start with a digit.
+# Hence, you should not prefix the version with 'v'.
+version: ${VERSION}
+
+# Version Release, aka revision.
+# This will expand any env var you set in the field, e.g. release: ${VERSION_RELEASE}
+# This is appended to the `version` after `prerelease`. This should be
+# incremented if you release an updated package of the same upstream version,
+# and it should reset to 1 when bumping the version.
+release: "${VERSION_RELEASE}"
+
+# Section.
+# This is only used by the deb packager.
+# See: https://www.debian.org/doc/debian-policy/ch-archive.html#sections
+section: default
+
+# Priority.
+# Defaults to `optional` on deb
+# Defaults to empty on rpm and apk
+# See: https://www.debian.org/doc/debian-policy/ch-archive.html#priorities
+priority: extra
+
+maintainer: thin-edge.io <info@thin-edge.io>
+description: |
+  An Open Source MQTT v3.1/v3.1.1 Broker
+
+  Mosquitto is an open source message broker that implements the MQ Telemetry
+  Transport protocol version 3.1 and 3.1.1 MQTT provides a lightweight method
+  of carrying out messaging using a publish/subscribe model. This makes it
+  suitable for "machine to machine" messaging such as with low power sensors
+  or mobile devices such as phones, embedded computers or micro-controllers
+  like the Arduino.
+
+vendor: thin-edge.io
+homepage: https://thin-edge.io
+license: BSD
+
+disable_globbing: false
+
+provides:
+  - mosquitto
+
+replaces:
+  - mosquitto
+  - tedge-mosquitto-notls
+
+contents:
+  - src: zig-out/bin/mosquitto
+    dst: /usr/sbin/mosquitto
+    file_info:
+      mode: 0755
+
+  - src: packaging/conf/certs/README
+    dst: /etc/mosquitto/certs/README
+    type: config
+
+  - src: packaging/conf/ca_certificates/README
+    dst: /etc/mosquitto/ca_certificates/README
+    type: config
+
+  - src: packaging/conf/mosquitto.conf
+    dst: /etc/mosquitto/mosquitto.conf
+    type: config
+
+  - src: packaging/conf/conf.d/README
+    dst: /etc/mosquitto/conf.d/README
+    type: config
+
+  # systemd definition
+  - src: packaging/services/systemd/mosquitto.service
+    dst: /usr/lib/systemd/system/mosquitto.service
+    file_info:
+      mode: 0644
+
+# Scripts to run at specific stages
+scripts:
+  preinstall: ./packaging/scripts/preinstall.sh
+  postinstall: ./packaging/scripts/postinstall.sh
+  preremove: ./packaging/scripts/preremove.sh
+  postremove: ./packaging/scripts/postremove.sh

--- a/packaging/rpm/mosquitto.spec
+++ b/packaging/rpm/mosquitto.spec
@@ -1,0 +1,151 @@
+%define major     2
+%define minor     1
+%define libname   %mklibname %{name} %{major}
+%define libnamepp %mklibname %{name}pp %{major}
+%define develname %mklibname %{name} -d
+
+Name:           mosquitto
+Version:        2.0.20
+Release:        1
+Summary:        An Open Source MQTT v3.1/v3.1.1 Broker
+Group:          System/Libraries
+License:        BSD
+URL:            http://mosquitto.org/
+Source0:        http://mosquitto.org/files/source/%{name}-%{version}.tar.gz
+Source1:        %{name}-sysusers.conf
+BuildRequires:  cmake
+BuildRequires:  tcp_wrappers-devel
+BuildRequires:  uthash-devel >= 2.1.0
+BuildRequires:  cmake(cJSON)
+BuildRequires:  pkgconfig(libcares)
+BuildRequires:  pkgconfig(libwebsockets)
+BuildRequires:  pkgconfig(openssl)
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  pkgconfig(uuid)
+BuildRequires:  xsltproc
+Requires:		%{libname} = %{version}-%{release}
+Requires(pre):  shadow-utils
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+Mosquitto is an open source message broker that implements the MQ Telemetry
+Transport protocol version 3.1 and 3.1.1 MQTT provides a lightweight method
+of carrying out messaging using a publish/subscribe model. This makes it
+suitable for "machine to machine" messaging such as with low power sensors
+or mobile devices such as phones, embedded computers or micro-controllers
+like the Arduino.
+
+%files
+%doc ChangeLog.txt CONTRIBUTING.md README*
+%license LICENSE.txt
+%{_bindir}/%{name}*
+%{_sbindir}/%{name}
+%dir %{_sysconfdir}/%{name}
+%config(noreplace) %{_sysconfdir}/%{name}/%{name}.conf
+%config %{_sysconfdir}/%{name}/*.example
+%{_sysusersdir}/%{name}.conf
+%{_unitdir}/%{name}.service
+%{_mandir}/man1/*.1.*
+%{_mandir}/man5/*.5.*
+%{_mandir}/man7/*.7.*
+%{_mandir}/man8/*.8.*
+
+%pre
+%sysusers_create_package %{name} %{S:1}
+
+%post
+%systemd_post %{name}
+
+%preun
+%systemd_preun %{name}
+
+%postun
+%systemd_postun %{name}
+
+#------------------------------------------------
+
+%package -n     %{libname}
+Summary:        An Open Source MQTT v3.1/v3.1.1 Broker
+Group:          System/Libraries
+
+%description -n %{libname}
+Mosquitto is an open source message broker that implements the MQ Telemetry
+Transport protocol version 3.1 and 3.1.1 MQTT provides a lightweight method
+of carrying out messaging using a publish/subscribe model. This makes it
+suitable for "machine to machine" messaging such as with low power sensors
+or mobile devices such as phones, embedded computers or micro-controllers
+like the Arduino.
+
+%files -n %{libname}
+%{_libdir}/lib%{name}.so.%{major}*
+%{_libdir}/lib%{name}.so.%{minor}*
+
+#------------------------------------------------
+
+%package -n     %{libnamepp}
+Summary:        An Open Source MQTT v3.1/v3.1.1 Broker
+Group:          System/Libraries
+Requires:		%{libname} = %{version}-%{release}
+
+%description -n %{libnamepp}
+Mosquitto is an open source message broker that implements the MQ Telemetry
+Transport protocol version 3.1 and 3.1.1 MQTT provides a lightweight method
+of carrying out messaging using a publish/subscribe model. This makes it
+suitable for "machine to machine" messaging such as with low power sensors
+or mobile devices such as phones, embedded computers or micro-controllers
+like the Arduino.
+
+%files -n %{libnamepp}
+%{_libdir}/lib%{name}pp.so.%{major}*
+%{_libdir}/lib%{name}pp.so.%{minor}*
+
+#------------------------------------------------
+
+%package -n     %{develname}
+Summary:        Development package for %{name}
+Group:          Development/C++
+Requires:       %{libname} = %{version}-%{release}
+Requires:       %{libnamepp} = %{version}-%{release}
+Provides:       %{name}-devel = %{version}-%{release}
+
+%description -n %{develname}
+Header files for development with %{name}.
+
+%files -n %{develname}
+%{_includedir}/*.h
+%{_libdir}/*.so
+%{_libdir}/pkgconfig/*.pc
+%{_mandir}/man3/*.3.*
+
+#------------------------------------------------
+
+%prep
+%setup -q
+
+# Don't strip binaries on install: rpmbuild will take care of it
+sed -i "s|(INSTALL) -s|(INSTALL)|g" lib/Makefile src/Makefile client/Makefile
+
+# fix link with libwebsockets
+sed -i "s|websockets_shared|websockets|g" src/CMakeLists.txt
+
+%build
+%cmake \
+     -DCMAKE_INSTALL_SYSCONFDIR=%{_sysconfdir} \
+     -DWITH_BUNDLED_DEPS=OFF \
+     -DWITH_SYSTEMD=ON \
+     -DWITH_WEBSOCKETS=ON
+%make
+
+%install
+%makeinstall_std -C build
+
+mkdir -p %{buildroot}%{_unitdir}
+install -p -m 0644 service/systemd/%{name}.service.notify %{buildroot}%{_unitdir}/%{name}.service
+
+install -D %{S:1} %{buildroot}%{_sysusersdir}/%{name}.conf
+
+%check
+#make test
+

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+if command -V systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload ||:
+    systemctl restart mosquitto ||:
+fi

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -e
+
+command_exists() {
+    command -V "$1" >/dev/null 2>&1
+}
+
+group_exists() {
+    name="$1"
+    if command_exists id; then
+        id -g "$name" >/dev/null 2>&1
+    elif command_exists getent; then
+        getent group "$name" >/dev/null 2>&1
+    else
+        # Fallback to plain grep, as busybox does not have getent
+        grep -q "^${name}:" /etc/group
+    fi
+}
+
+user_exists() {
+    name="$1"
+    if command_exists id; then
+        id -u "$name" >/dev/null 2>&1
+    elif command_exists getent; then
+        getent passwd "$name" >/dev/null 2>&1
+    else
+        # Fallback to plain grep, as busybox does not have getent
+        grep -q "^${name}:" /etc/passwd
+    fi
+}
+
+remove_user() {
+    name="$1"
+    if user_exists "$name"; then
+        if command_exists userdel; then
+            userdel "$name"
+        elif command_exists deluser; then
+            deluser "$name"
+        else
+            echo "WARNING: Could not delete group: $name" >&2
+        fi
+    fi
+}
+
+remove_group() {
+    name="$1"
+    if group_exists "$name"; then
+        if command_exists groupdel; then
+            groupdel "$name"
+        elif command_exists delgroup; then
+            delgroup "$name"
+        else
+            echo "WARNING: Could not delete group: $name" >&2
+        fi
+    fi
+}
+
+purge_configs() {
+    if [ -d "/etc/mosquitto" ]; then
+        rm -rf /etc/mosquitto
+    fi
+}
+
+purge_var_log() {
+    if [ -d "/var/log/mosquitto" ]; then
+        rm -rf /var/log/mosquitto
+    fi
+}
+
+
+case "$1" in
+    purge)
+        remove_user "mosquitto"
+        remove_group "mosquitto"
+        purge_configs
+        purge_var_log
+    ;;
+esac

--- a/packaging/scripts/preinstall.sh
+++ b/packaging/scripts/preinstall.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+set -e
+
+command_exists() {
+    command -V "$1" >/dev/null 2>&1
+}
+
+group_exists() {
+    name="$1"
+    if command_exists id; then
+        id -g "$name" >/dev/null 2>&1
+    elif command_exists getent; then
+        getent group "$name" >/dev/null 2>&1
+    else
+        # Fallback to plain grep, as busybox does not have getent
+        grep -q "^${name}:" /etc/group
+    fi
+}
+
+user_exists() {
+    name="$1"
+    if command_exists id; then
+        id -u "$name" >/dev/null 2>&1
+    elif command_exists getent; then
+        getent passwd "$name" >/dev/null 2>&1
+    else
+        # Fallback to plain grep, as busybox does not have getent
+        grep -q "^${name}:" /etc/passwd
+    fi
+}
+
+### Create groups
+if ! group_exists mosquitto; then
+    if command_exists groupadd; then
+        groupadd --system mosquitto
+    elif command_exists addgroup; then
+        addgroup -S mosquitto
+    else
+        echo "WARNING: Could not create group: mosquitto" >&2
+    fi
+fi
+
+### Create users
+# Create user with no home(--no-create-home), no login(--shell) and in group mosquitto(--gid)
+if ! user_exists mosquitto; then
+    if command_exists useradd; then
+        useradd --system --no-create-home --shell /sbin/nologin --gid mosquitto mosquitto
+    elif command_exists adduser; then
+        adduser -g "" -H -D mosquitto -G mosquitto
+    else
+        echo "WARNING: Could not create user: mosquitto" >&2
+    fi
+fi

--- a/packaging/scripts/preremove.sh
+++ b/packaging/scripts/preremove.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+set -e

--- a/packaging/services/systemd/mosquitto.service
+++ b/packaging/services/systemd/mosquitto.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Mosquitto MQTT Broker
+Documentation=man:mosquitto.conf(5) man:mosquitto(8)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/sbin/mosquitto -c /etc/mosquitto/mosquitto.conf
+ExecReload=/bin/kill -HUP $MAINPID
+Restart=on-failure
+ExecStartPre=/bin/mkdir -m 740 -p /var/log/mosquitto
+ExecStartPre=/bin/chown mosquitto:mosquitto /var/log/mosquitto
+ExecStartPre=/bin/mkdir -m 740 -p /run/mosquitto
+ExecStartPre=/bin/chown mosquitto:mosquitto /run/mosquitto
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Add support for building with and without TLS and add linux packaging:

Below is a list of the features:

* Add just file to run common project tasks
* Add openssl dependency which is used when the TLS option is enabled
* Add linux packaging (called "tedge-mosquitto" and "tedge-mosquitto-notls", both which will override the "mosquitto" package, but also will satisfy tedge-full's dependency to mosquitto)