### PR TITLE
feat: make mosquitto version configurable in the build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,22 @@ Cross compile mosquitto using zig build (tested with ziglang 0.14.0).
     just checkout-mosquitto
     ```
 
+    Or you can specify the mosquitto version by setting the `VERSION` environment variable.
+
+    ```sh
+    VERSION=2.0.21 just checkout-mosquitto
+    ```
+
 3. Build all targets
 
     ```sh
     just build-all
+    ```
+
+    Or specify the `VERSION` environment variable.
+
+    ```sh
+    VERSION=2.0.21 just build-all
     ```
 
     If you don't want to include TLS, then you can run:
@@ -109,5 +121,4 @@ zig-out/bin/mosquitto: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV),
 
 The following items are still yet to be addressed/fixed:
 
-* [ ] Mosquitto version should not be hardcoded
 * [ ] Support for other init systems like OpenRC, SysVInit, s6-overlay

--- a/build.zig
+++ b/build.zig
@@ -4,6 +4,7 @@ pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
     const with_tls = b.option(bool, "WITH_TLS", "Build mosquitto with TLS") orelse false;
+    const version = b.option([]const u8, "version", "mosquitto version string") orelse "0.0.0";
 
     const mosquitto = b.addExecutable(.{
         .name = "mosquitto",
@@ -124,7 +125,12 @@ pub fn build(b: *std.Build) !void {
     try mosquitto_flags.append("-DWITH_BRIDGE");
     try mosquitto_flags.append("-DWITH_BROKER");
     try mosquitto_flags.append("-DWITH_PERSISTENCE");
-    try mosquitto_flags.append("-DVERSION=\"2.0.18\"");
+
+    // version
+    const version_flag = try std.fmt.allocPrint(alloc, "-DVERSION=\"{s}\"", .{version});
+    defer alloc.free(version_flag);
+    try mosquitto_flags.append(version_flag);
+
     try mosquitto_flags.append("-Wall");
     try mosquitto_flags.append("-W");
 

--- a/justfile
+++ b/justfile
@@ -32,7 +32,7 @@ checkout-mosquitto version=VERSION:
 
 # build the binary without tls
 build-notls target=TARGET package_arch=PACKAGE_TARGET:
-    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} {{BUILD_OPTIONS}}
+    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} -Dversion={{VERSION}} {{BUILD_OPTIONS}}
     mkdir -p dist/
     PACKAGE_NAME="{{PACKAGE_NAME}}-notls" REVISION={{REVISION}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p rpm -f ./packaging/nfpm.yaml -t {{OUTPUT_DIR}}/
     PACKAGE_NAME="{{PACKAGE_NAME}}-notls" REVISION={{REVISION}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p apk -f ./packaging/nfpm.yaml -t {{OUTPUT_DIR}}/
@@ -40,7 +40,7 @@ build-notls target=TARGET package_arch=PACKAGE_TARGET:
 
 # build the binary with tls enabled (default)
 build target=TARGET package_arch=PACKAGE_TARGET:
-    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} -DWITH_TLS=true {{BUILD_OPTIONS}}
+    zig build -Doptimize=ReleaseSmall -Dtarget={{target}} -Dversion={{VERSION}} -DWITH_TLS=true {{BUILD_OPTIONS}}
     mkdir -p dist/
     PACKAGE_NAME="{{PACKAGE_NAME}}" REVISION={{REVISION}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p rpm -f ./packaging/nfpm.yaml -t {{OUTPUT_DIR}}/
     PACKAGE_NAME="{{PACKAGE_NAME}}" REVISION={{REVISION}} VERSION={{VERSION}} ARCH={{package_arch}} nfpm package -p apk -f ./packaging/nfpm.yaml -t {{OUTPUT_DIR}}/


### PR DESCRIPTION
Add the `version` as a user build option in the build.zig file. This avoids the previously hardcoded value.