### PR TITLE
fix: use commit hash for mosquitto 2.1.0-develop branch

### DIFF
--- a/build/2.1.0-develop/build.zig.zon
+++ b/build/2.1.0-develop/build.zig.zon
@@ -10,8 +10,8 @@
     },
     .dependencies = .{
         .mosquitto_src = .{
-            .url = "https://github.com/eclipse-mosquitto/mosquitto/archive/refs/heads/develop.tar.gz",
-            .hash = "N-V-__8AAMxQigB8Afzr8oIL9Ljuf5OSO37L58pLHNXwvdxJ",
+            .url = "https://github.com/eclipse-mosquitto/mosquitto/archive/79a13f6e107c2f3fed8bf34a4c0f1b452696474c.tar.gz",
+            .hash = "N-V-__8AAIptigAW2eBQ9PXDQwxcxQfzB2RuDhQqvp7f7xnw",
         },
         .cjson = .{
             .url = "https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.18.tar.gz",


### PR DESCRIPTION
Change mosquitto 2.1.0 version to use a specific commit (from the develop branch) to ensure that the build still works when new commits are added to the mosquitto project