### PR TITLE
feat: add sysvinit service definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 mosquitto
 mosquitto*.tar.gz
 mosquitto*/
+!packaging/services/sysvinit/mosquitto
 cjson/
 zig-out/
 .zig-cache/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -141,11 +141,24 @@ nfpms:
         dst: /etc/mosquitto/conf.d/README
         type: config
 
+      - dst: /var/lib/mosquitto
+        type: dir
+        file_info:
+          owner: mosquitto
+          group: mosquitto
+          mode: 700
+
       # systemd definition
       - src: packaging/services/systemd/mosquitto.service
         dst: /usr/lib/systemd/system/mosquitto.service
         file_info:
           mode: 0644
+
+      # sysvinit definition
+      - src: packaging/services/sysvinit/mosquitto
+        dst: /usr/lib/tedge-services/sysvinit/mosquitto
+        file_info:
+          mode: 0755
 
     scripts:
       preinstall: ./packaging/scripts/preinstall.sh

--- a/packaging/scripts/postinstall.sh
+++ b/packaging/scripts/postinstall.sh
@@ -1,7 +1,63 @@
 #!/bin/sh
 set -e
 
-if command -V systemctl >/dev/null 2>&1; then
-    systemctl daemon-reload ||:
-    systemctl restart mosquitto ||:
+system_command_exists() {
+    # Note: system commands might not be in the path for a non-root
+    # user, e.g. under /sbin and /usr/sbin. This may result in some false
+    # negatives. Use a modified path when checking the existence for
+    # more consistent results
+	PATH="$PATH:/sbin:/usr/sbin" command -v "$@" > /dev/null 2>&1
+}
+
+#
+# Detect service manager
+#
+SERVICE_MANAGER=
+if system_command_exists systemctl; then
+    SERVICE_MANAGER="systemd"
+elif system_command_exists rc-service; then
+    SERVICE_MANAGER="openrc"
+elif system_command_exists update-rc.d; then
+    SERVICE_MANAGER="sysvinit"
+elif [ -f /command/s6-rc ]; then
+    SERVICE_MANAGER="s6_overlay"
+elif system_command_exists runsv; then
+    SERVICE_MANAGER="runit"
+elif system_command_exists supervisorctl; then
+    SERVICE_MANAGER="supervisord"
+else
+    echo "WARNING: Could not detect the init system. Only openrc,runit,systemd,sysvinit,s6_overlay,supervisord are supported" >&2
 fi
+
+case "$SERVICE_MANAGER" in
+    systemd)
+        systemctl daemon-reload ||:
+        systemctl restart mosquitto ||:
+        ;;
+    sysvinit)
+        cp /usr/lib/tedge-services/sysvinit/mosquitto /etc/init.d/
+
+        if [ ! -e /var/log/syslog ]; then
+            # log to stderr if syslog is not available
+            if [ -f /etc/mosquitto/mosquitto.conf ]; then
+                sed -i 's/^log_dest .*/log_dest stderr/' /etc/mosquitto/mosquitto.conf ||:
+            fi
+        fi
+
+        update-rc.d mosquitto defaults ||:
+
+        # Not all sysvinit systems support the enable/disable command
+        update-rc.d mosquitto enable 2>/dev/null ||:
+
+        if command -V service >/dev/null 2>&1; then
+            service mosquitto restart
+        else
+            # Use stop then start as some services the pid file
+            # does not get deleted quick enough before starting, which results in the start failing.
+            # This problem was observed on an opto-22 device when restarting mosquitto
+            /etc/init.d/mosquitto stop
+            sleep 1
+            /etc/init.d/mosquitto start
+        fi
+        ;;
+esac

--- a/packaging/scripts/postremove.sh
+++ b/packaging/scripts/postremove.sh
@@ -67,6 +67,10 @@ purge_var_log() {
     fi
 }
 
+remove_service() {
+    rm -f /etc/init.d/mosquitto
+}
+
 
 case "$1" in
     purge)
@@ -74,5 +78,6 @@ case "$1" in
         remove_group "mosquitto"
         purge_configs
         purge_var_log
+        remove_service
     ;;
 esac

--- a/packaging/services/sysvinit/mosquitto
+++ b/packaging/services/sysvinit/mosquitto
@@ -1,0 +1,149 @@
+#!/bin/sh
+#/etc/init.d/mosquitto: MQTT broker
+
+### BEGIN INIT INFO
+# Provides:          mosquitto
+# Short-Description: MQTT broker
+# Required-Start:    $all
+# Required-Stop:     $all
+# Should-Start:      
+# Should-Stop:       
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+### END INIT INFO
+
+# shellcheck disable=SC1090
+# shellcheck disable=SC1091
+
+set -e
+
+PATH=/bin:/usr/bin:/sbin:/usr/sbin
+
+test -x "/usr/sbin/mosquitto" || exit 0
+
+# For configuration of the init script use the file
+# /etc/default/mosquitto, do not edit this init script.
+
+# Set run_service to 1 to start mosquitto or 0 to disable it.
+run_service=1
+
+DAEMON_ARGS="-c /etc/mosquitto/mosquitto.conf"
+DAEMON_USER="mosquitto"
+LOG_FILE=/var/log/mosquitto.log
+
+[ -e "/etc/default/mosquitto" ] && . "/etc/default/mosquitto"
+
+DAEMON=/usr/sbin/mosquitto
+PIDFILE=/run/lock/mosquitto.lock
+if [ -d /run/lock ]; then
+    PIDFILE=/run/lock/mosquitto.lock
+else
+    PIDFILE=/var/run/mosquitto.lock
+fi
+
+STOP_RETRY_SCHEDULE='TERM/30/KILL/1'
+
+# Mock Debian helper functions when not being run on a debian based OS
+log_begin_msg() {
+    printf "%s" "$*"
+}
+
+log_end_msg() {
+    if [ "$1" = "0" ]; then
+        echo 'done'
+    else
+        echo 'error'
+    fi
+}
+
+log_daemon_msg() {
+    echo "$*"
+}
+
+log_progress_msg() {
+    echo "$*"
+}
+
+# TODO: Can the imports be excluded if the mocked functions are used above?
+if [ -f /lib/lsb/init-functions ]; then
+	# Debian based systems including WSL (ubuntu)
+	. /lib/lsb/init-functions
+fi
+
+if [ -f /etc/init.d/functions ]; then
+	# YOCTO
+	. /etc/init.d/functions
+fi
+
+do_start() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Starting mosquitto daemon..."
+
+        # Create log file with given user so it can write to it (for non-root users)
+        touch "$LOG_FILE"
+        if [ -n "$DAEMON_USER" ]; then
+            chown "$DAEMON_USER" "$LOG_FILE"
+        fi
+
+        start-stop-daemon --start --quiet --oknodo --background --make-pidfile --pidfile "$PIDFILE" --chuid "${DAEMON_USER}" --user "${DAEMON_USER}" \
+                --startas /bin/sh -- -c "exec $DAEMON $DAEMON_ARGS >> '$LOG_FILE' 2>&1"
+        log_end_msg $?
+    fi
+}
+
+do_stop() {
+    if [ $run_service = 1 ]
+    then
+        log_begin_msg "Stopping mosquitto daemon..."
+
+        if start-stop-daemon --stop --quiet --oknodo --retry "$STOP_RETRY_SCHEDULE" --pidfile "${PIDFILE}" --user "${DAEMON_USER}"; then
+            log_end_msg 0
+            rm -f "${PIDFILE}"
+        else
+            log_end_msg 1
+        fi
+    fi
+}
+
+case "$1" in
+  start)
+    do_start
+    ;;
+
+  stop)
+    do_stop
+    ;;
+
+  restart)
+    do_stop
+    do_start
+    ;;
+
+  try-restart|force-reload)
+      if [ $run_service = 0 ]; then exit 0; fi
+    log_daemon_msg "Restarting mosquitto"
+    # force-reload is the same as reload or try-restart according
+    # to its definition, the reload is not implemented here, so
+    # force-reload is the alias of try-restart here, but it should
+    # be the alias of reload if reload is implemented.
+    #
+    # Only start the service when do_stop succeeds
+    do_stop && do_start
+    ;;
+
+  status)
+    if command -V status_of_proc >/dev/null 2>&1; then
+        status_of_proc -p "${PIDFILE}" "${DAEMON}" "mosquitto" && exit 0 || exit $?
+    else
+        status "${DAEMON}" && exit 0 || exit $?
+    fi
+    ;;
+
+  *)
+    echo "Usage: /etc/init.d/mosquitto {start|stop|status|restart|try-restart|force-reload}" >&2
+    exit 1
+
+esac
+
+exit 0


### PR DESCRIPTION
Add a SysVInit service definition for older OS's. The init system will be auto detected and the sysvinit service will be moved to `/etc/init.d` only if sysvinit is being used.

There is provisions for adding additional service definitions, however these can be added at a later time.