### PR TITLE
feat: build for more mosquitto versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,7 +19,7 @@ jobs:
           - { version: '2.0.18', tls: true, no_tls: true }
           - { version: '2.0.22', tls: true, no_tls: true }
           - { version: '2.1.2', tls: true, no_tls: false }
-          - { version: '2.1.x-master', tls: true, no_tls: false }
+          # - { version: '2.1.x-master', tls: true, no_tls: false }
 
     env:
       VERSION: ${{ matrix.job.version }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
           - { version: '2.0.11', tls: true, no_tls: true }
           - { version: '2.0.18', tls: true, no_tls: true }
           - { version: '2.0.22', tls: true, no_tls: true }
-          - { version: '2.1.0', tls: true, no_tls: false }
+          - { version: '2.1.2', tls: true, no_tls: false }
           - { version: '2.1.x-master', tls: true, no_tls: false }
 
     env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,11 +44,11 @@ jobs:
 
       - name: Build with tls
         if: ${{ matrix.job.tls }}
-        run: just build
+        run: just WITH_TLS=true build
 
       - name: Build without tls
         if: ${{ matrix.job.no_tls }}
-        run: just build-notls
+        run: just WITH_TLS=false build
       
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,9 +15,11 @@ jobs:
       fail-fast: false
       matrix:
         job:
+          - { version: '2.0.11', tls: true, no_tls: true }
           - { version: '2.0.18', tls: true, no_tls: true }
           - { version: '2.0.22', tls: true, no_tls: true }
-          - { version: '2.1.0-develop', tls: true, no_tls: false }
+          - { version: '2.1.0', tls: true, no_tls: false }
+          - { version: '2.1.x-master', tls: true, no_tls: false }
 
     env:
       VERSION: ${{ matrix.job.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist/
 .env
 build/*/packaging
 build/*/zig-out
+build/*/zig-pkg
 /current

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cross compile mosquitto using zig build (tested with ziglang 0.15.1).
 
 * ziglang 0.15.1
 * [just](https://github.com/casey/just) >= 1.15.0
-* [goreleaser](https://github.com/goreleaser/goreleaser) >= 2.13 (to coordinate the build and packaging)
+* [goreleaser](https://github.com/goreleaser/goreleaser) >= 2.15 (to coordinate the build and packaging)
 * UPX (optional: used to provide self-extracting binaries for devices with very limited file storage)
 
 **Note**
@@ -37,13 +37,13 @@ The mosquitto source code is downloaded automatically using the ziglang build sy
     Or specify the `VERSION` environment variable.
 
     ```sh
-    VERSION=2.0.22 just build
+    just VERSION=2.0.22 build
     ```
 
     If you don't want to include TLS, then you can run:
 
     ```sh
-    just build-notls
+    just VERSION=2.0.22 WITH_TLS=false build
     ```
 
 3. Use the build linux packages under the `dist/` folder

--- a/build/2.0.11/build.zig.zon
+++ b/build/2.0.11/build.zig.zon
@@ -1,0 +1,21 @@
+.{
+    .name = .mosquitto,
+    .version = "2.0.11",
+    .fingerprint = 0xedaa03191382deac,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+    .dependencies = .{
+        .mosquitto_src = .{
+            .url = "https://mosquitto.org/files/source/mosquitto-2.0.11.tar.gz",
+            .hash = "N-V-__8AANaEOwBQ_qjxuL5jvkIMp8f99gKikiKCtBBh8sNE",
+        },
+        .openssl = .{
+            .url = "https://github.com/dzfrias/openssl-zig/archive/8f9dd2791a5ec743c85e57fb1ef9c59e99c5d222.tar.gz",
+            .hash = "openssl-3.6.0-YymhPrUoAQCKRYLwvQUcGnmdVPu-fBBsq37GSaIx0ZMy",
+        },
+    }
+}

--- a/build/2.0.18/build.zig.zon
+++ b/build/2.0.18/build.zig.zon
@@ -14,7 +14,7 @@
             .hash = "N-V-__8AADKsQADqbe01XDT7fXb_eOfh3ViJ3j-5EQdSr3WR",
         },
         .openssl = .{
-            .url = "https://github.com/dzfrias/openssl-zig/archive/refs/heads/main.tar.gz",
+            .url = "https://github.com/dzfrias/openssl-zig/archive/8f9dd2791a5ec743c85e57fb1ef9c59e99c5d222.tar.gz",
             .hash = "openssl-3.6.0-YymhPrUoAQCKRYLwvQUcGnmdVPu-fBBsq37GSaIx0ZMy",
         },
     }

--- a/build/2.0.22/build.zig.zon
+++ b/build/2.0.22/build.zig.zon
@@ -14,7 +14,7 @@
             .hash = "N-V-__8AAFZMQQCBNkzH4l0rLKXlBPKWOVHuadFkfj47fiFw",
         },
         .openssl = .{
-            .url = "https://github.com/dzfrias/openssl-zig/archive/refs/heads/main.tar.gz",
+            .url = "https://github.com/dzfrias/openssl-zig/archive/8f9dd2791a5ec743c85e57fb1ef9c59e99c5d222.tar.gz",
             .hash = "openssl-3.6.0-YymhPrUoAQCKRYLwvQUcGnmdVPu-fBBsq37GSaIx0ZMy",
         },
     },

--- a/build/2.1.2/build.zig
+++ b/build/2.1.2/build.zig
@@ -1,0 +1,216 @@
+const std = @import("std");
+const zon = @import("build.zig.zon");
+
+pub fn build(b: *std.Build) !void {
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    const alloc = gpa.allocator();
+
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    // NOTE: Force with_tls as building without tls currently fails due to missing ifdef in the mosquitto source code
+    const with_tls = b.option(bool, "WITH_TLS", "Build mosquitto with TLS") orelse true;
+    const version = b.option([]const u8, "version", "mosquitto version string") orelse zon.version;
+
+    const mosquitto = b.addExecutable(.{
+        .name = "mosquitto",
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+
+    const mosquitto_dep = b.dependency("mosquitto_src", .{});
+    mosquitto.addIncludePath(mosquitto_dep.path(""));
+    mosquitto.addIncludePath(mosquitto_dep.path("src"));
+    mosquitto.addIncludePath(mosquitto_dep.path("common"));
+    mosquitto.addIncludePath(mosquitto_dep.path("lib"));
+    mosquitto.addIncludePath(mosquitto_dep.path("libcommon"));
+    mosquitto.addIncludePath(mosquitto_dep.path("deps"));
+    mosquitto.addIncludePath(mosquitto_dep.path("include"));
+
+    const cjson_dep = b.dependency("cjson", .{});
+    const mkdir_cjson = b.addSystemCommand(&[_][]const u8{ "mkdir", "-p", "cjson" });
+    const copy_cjson = b.addSystemCommand(&[_][]const u8{"cp"});
+    copy_cjson.addFileArg(cjson_dep.path("cJSON.h"));
+    copy_cjson.addArg("cjson/cJSON.h");
+    copy_cjson.step.dependOn(&mkdir_cjson.step);
+    mosquitto.step.dependOn(&copy_cjson.step);
+    mosquitto.addIncludePath(b.path("."));
+    mosquitto.addCSourceFile(.{ .file = cjson_dep.path("cJSON.c"), .flags = &.{} });
+
+    const sqlite_dep = b.dependency("sqlite", .{});
+    mosquitto.addIncludePath(sqlite_dep.path("."));
+    mosquitto.addCSourceFile(.{ .file = sqlite_dep.path("sqlite3.c"), .flags = &.{} });
+
+    const microhttpd = b.dependency("microhttpd", .{});
+    mosquitto.addIncludePath(microhttpd.path("src/include"));
+
+    // Enable openssl
+    if (with_tls) {
+        const openssl = b.dependency("openssl", .{ .target = target, .optimize = optimize });
+        const libssl = openssl.artifact("ssl");
+        const libcrypto = openssl.artifact("crypto");
+        _ = for (libcrypto.root_module.include_dirs.items) |include_dir| {
+            try mosquitto.root_module.include_dirs.append(b.allocator, include_dir);
+        };
+        mosquitto.root_module.linkLibrary(libssl);
+        mosquitto.root_module.linkLibrary(libcrypto);
+    }
+
+    // note: Ideally the source code files should be sorted and the unused files should
+    // be commented out rather than deleted from the list to make it easier to see what
+    // is and isn't used
+    const mosquitto_sources = [_][]const u8{
+        "common/json_help.c",
+
+        "libcommon/base64_common.c",
+        "libcommon/cjson_common.c",
+        "libcommon/file_common.c",
+        "libcommon/memory_common.c",
+        "libcommon/mqtt_common.c",
+        "libcommon/password_common.c",
+        "libcommon/property_common.c",
+        "libcommon/random_common.c",
+        "libcommon/strings_common.c",
+        "libcommon/time_common.c",
+        "libcommon/topic_common.c",
+        "libcommon/utf8_common.c",
+
+        "lib/alias_mosq.c",
+        "lib/handle_ping.c",
+        "lib/handle_pubackcomp.c",
+        "lib/handle_pubrec.c",
+        "lib/handle_pubrel.c",
+        "lib/handle_suback.c",
+        "lib/handle_unsuback.c",
+        "lib/net_mosq_ocsp.c",
+        "lib/net_mosq.c",
+        "lib/net_ws.c",
+        "lib/packet_datatypes.c",
+        "lib/packet_mosq.c",
+        "lib/property_mosq.c",
+        "lib/send_mosq.c",
+        "lib/send_connect.c",
+        "lib/send_disconnect.c",
+        "lib/send_publish.c",
+        "lib/send_subscribe.c",
+        "lib/send_unsubscribe.c",
+        "lib/tls_mosq.c",
+        "lib/util_mosq.c",
+        "lib/will_mosq.c",
+
+        "plugins/acl-file/acl_check.c",
+        "plugins/acl-file/acl_parse.c",
+        "plugins/password-file/password_check.c",
+        "plugins/password-file/password_parse.c",
+
+        "src/acl_file.c",
+        "src/bridge.c",
+        "src/bridge_topic.c",
+        "src/broker_control.c",
+        "src/conf.c",
+        "src/conf_includedir.c",
+        "src/context.c",
+        "src/control.c",
+        "src/control_common.c",
+        "src/database.c",
+        "src/handle_auth.c",
+        "src/handle_connack.c",
+        "src/handle_connect.c",
+        "src/handle_disconnect.c",
+        "src/handle_publish.c",
+        "src/handle_subscribe.c",
+        "src/handle_unsubscribe.c",
+        "src/http_api.c",
+        "src/http_serv.c",
+        "src/keepalive.c",
+        "src/listeners.c",
+        "src/logging.c",
+        "src/loop.c",
+        "src/mosquitto.c",
+        "src/mux.c",
+        "src/mux_epoll.c",
+        "src/mux_kqueue.c",
+        "src/mux_poll.c",
+        "src/net.c",
+        "src/password_file.c",
+        "src/persist_read.c",
+        "src/persist_read_v234.c",
+        "src/persist_read_v5.c",
+        "src/persist_write.c",
+        "src/persist_write_v5.c",
+        "src/plugin_acl_check.c",
+        "src/plugin_basic_auth.c",
+        "src/plugin_callbacks.c",
+        "src/plugin_cleanup.c",
+        "src/plugin_client_offline.c",
+        "src/plugin_connect.c",
+        "src/plugin_disconnect.c",
+        "src/plugin_extended_auth.c",
+        "src/plugin_init.c",
+        "src/plugin_message.c",
+        "src/plugin_persist.c",
+        "src/plugin_psk_key.c",
+        "src/plugin_public.c",
+        "src/plugin_reload.c",
+        "src/plugin_subscribe.c",
+        "src/plugin_tick.c",
+        "src/plugin_unsubscribe.c",
+        "src/plugin_v2.c",
+        "src/plugin_v3.c",
+        "src/plugin_v4.c",
+        "src/plugin_v5.c",
+        "src/property_broker.c",
+        "src/proxy_v1.c",
+        "src/proxy_v2.c",
+        "src/psk_file.c",
+        "src/read_handle.c",
+        "src/retain.c",
+        "src/security_default.c",
+        "src/send_auth.c",
+        "src/send_connack.c",
+        "src/send_suback.c",
+        "src/send_unsuback.c",
+        "src/service.c",
+        "src/session_expiry.c",
+        "src/signals.c",
+        "src/subs.c",
+        "src/sys_tree.c",
+        "src/topic_tok.c",
+        "src/watchdog.c",
+        "src/websockets.c",
+        "src/will_delay.c",
+        "src/xtreport.c",
+    };
+
+    // construct build arguments
+    var mosquitto_flags = std.array_list.Managed([]const u8).init(alloc);
+    defer mosquitto_flags.deinit();
+
+    // optional flags
+    if (with_tls) {
+        try mosquitto_flags.append("-DWITH_TLS");
+    }
+
+    // common flags
+    try mosquitto_flags.append("-DWITH_BRIDGE");
+    try mosquitto_flags.append("-DWITH_BROKER");
+    try mosquitto_flags.append("-DWITH_PERSISTENCE");
+    // try mosquitto_flags.append("-DWITH_SQLITE");
+    // try mosquitto_flags.append("-DWITH_HTTP_API");
+
+    // version
+    const version_flag = try std.fmt.allocPrint(alloc, "-DVERSION=\"{s}\"", .{version});
+    defer alloc.free(version_flag);
+    try mosquitto_flags.append(version_flag);
+
+    try mosquitto_flags.append("-Wall");
+    try mosquitto_flags.append("-W");
+
+    for (mosquitto_sources) |src| {
+        mosquitto.addCSourceFile(.{ .file = mosquitto_dep.path(src), .flags = mosquitto_flags.items });
+    }
+    mosquitto.linkLibC();
+
+    b.installArtifact(mosquitto);
+}

--- a/build/2.1.2/build.zig.zon
+++ b/build/2.1.2/build.zig.zon
@@ -1,0 +1,33 @@
+.{
+    .name = .mosquitto,
+    .version = "2.1.2",
+    .fingerprint = 0xedaa03191382deac,
+    .paths = .{
+        "build.zig",
+        "build.zig.zon",
+        "LICENSE",
+        "README.md",
+    },
+    .dependencies = .{
+        .mosquitto_src = .{
+            .url = "https://mosquitto.org/files/source/mosquitto-2.1.2.tar.gz",
+            .hash = "N-V-__8AALOujwBDeiGVxIdyfIjDCc9unXVCJ-c4WqmV1W0f",
+        },
+        .cjson = .{
+            .url = "https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.18.tar.gz",
+            .hash = "N-V-__8AAEtUEwCjxN-pP2y-8gqgzBd8fevALO1YhSDa1KtX",
+        },
+        .microhttpd = .{
+            .url = "https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-1.0.2.tar.gz",
+            .hash = "N-V-__8AAFovswBPTQ0MmfBG-glcX_wDwfmfX7WJI_1LZGaf",
+        },
+        .sqlite = .{
+            .url = "https://sqlite.org/2026/sqlite-amalgamation-3510200.zip",
+            .hash = "N-V-__8AALNmqgBz73I7J8GlQS_kCPTRgxS0rm8gXcEM8Evk",
+        },
+        .openssl = .{
+            .url = "https://github.com/dzfrias/openssl-zig/archive/8f9dd2791a5ec743c85e57fb1ef9c59e99c5d222.tar.gz",
+            .hash = "openssl-3.6.0-YymhPrUoAQCKRYLwvQUcGnmdVPu-fBBsq37GSaIx0ZMy",
+        },
+    },
+}

--- a/build/2.1.x-master/build.zig
+++ b/build/2.1.x-master/build.zig
@@ -7,7 +7,6 @@ pub fn build(b: *std.Build) !void {
 
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
-    // NOTE: Force with_tls as building without tls currently fails due to missing ifdef in the mosquitto source code
     const with_tls = b.option(bool, "WITH_TLS", "Build mosquitto with TLS") orelse true;
     const version = b.option([]const u8, "version", "mosquitto version string") orelse zon.version;
 
@@ -20,6 +19,7 @@ pub fn build(b: *std.Build) !void {
     });
 
     const mosquitto_dep = b.dependency("mosquitto_src", .{});
+
     mosquitto.addIncludePath(mosquitto_dep.path(""));
     mosquitto.addIncludePath(mosquitto_dep.path("src"));
     mosquitto.addIncludePath(mosquitto_dep.path("common"));

--- a/build/2.1.x-master/build.zig.zon
+++ b/build/2.1.x-master/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .mosquitto,
-    .version = "2.1.0-develop",
+    .version = "2.1.1-master",
     .fingerprint = 0xedaa03191382deac,
     .paths = .{
         "build.zig",
@@ -10,8 +10,8 @@
     },
     .dependencies = .{
         .mosquitto_src = .{
-            .url = "https://github.com/eclipse-mosquitto/mosquitto/archive/79a13f6e107c2f3fed8bf34a4c0f1b452696474c.tar.gz",
-            .hash = "N-V-__8AAIptigAW2eBQ9PXDQwxcxQfzB2RuDhQqvp7f7xnw",
+            .url = "https://github.com/eclipse-mosquitto/mosquitto/archive/aa4bfa68ab7ee3679df4fa55386ecbbd7a8e6037.tar.gz",
+            .hash = "N-V-__8AAC_zigAecz9f_FmNCzcXPiYRweH2739wNS7CmtAC",
         },
         .cjson = .{
             .url = "https://github.com/DaveGamble/cJSON/archive/refs/tags/v1.7.18.tar.gz",
@@ -26,7 +26,7 @@
             .hash = "N-V-__8AALNmqgBz73I7J8GlQS_kCPTRgxS0rm8gXcEM8Evk",
         },
         .openssl = .{
-            .url = "https://github.com/dzfrias/openssl-zig/archive/refs/heads/main.tar.gz",
+            .url = "https://github.com/dzfrias/openssl-zig/archive/8f9dd2791a5ec743c85e57fb1ef9c59e99c5d222.tar.gz",
             .hash = "openssl-3.6.0-YymhPrUoAQCKRYLwvQUcGnmdVPu-fBBsq37GSaIx0ZMy",
         },
     },

--- a/justfile
+++ b/justfile
@@ -1,19 +1,19 @@
 set dotenv-load
 
 # package name
-PACKAGE_NAME := env("PACKAGE_NAME", "tedge-mosquitto")
+export PACKAGE_NAME := env("PACKAGE_NAME", if WITH_TLS == "true" { "tedge-mosquitto" } else { "tedge-mosquitto-notls" })
 
 # package version
-VERSION := env("VERSION", "2.0.22")
+export VERSION := env("VERSION", "2.0.22")
 
 # package version release suffix
-REVISION := env("REVISION", "1")
+export REVISION := env("REVISION", "1")
 
 # output directory for the linux packages
 OUTPUT_DIR := "dist"
 
 # build mosquitto with tls. Accepts either 'true' or 'false'
-WITH_TLS := env("WITH_TLS", "true")
+export WITH_TLS := env("WITH_TLS", "true")
 
 # list supported mosquitto versions
 list-versions:
@@ -29,16 +29,19 @@ list-versions:
 # Note: use --parallelism 1 due to a problem when running builds in parallel, most likely
 # caused by the openssl dependency
 [private]
+_release *ARGS='':
+    GORELEASER_CURRENT_TAG={{VERSION}} REVISION={{REVISION}} WITH_TLS={{WITH_TLS}} PACKAGE_NAME="{{PACKAGE_NAME}}" goreleaser release --parallelism 1 --auto-snapshot --skip=announce,publish,validate --clean {{ARGS}}
+
+[private]
 _build *ARGS='':
-    VERSION={{VERSION}} REVISION={{REVISION}} WITH_TLS={{WITH_TLS}} PACKAGE_NAME="{{PACKAGE_NAME}}" goreleaser release --parallelism 1 --auto-snapshot --skip=announce,publish,validate --clean {{ARGS}}
+    GORELEASER_CURRENT_TAG={{VERSION}} REVISION={{REVISION}} WITH_TLS={{WITH_TLS}} PACKAGE_NAME="{{PACKAGE_NAME}}" goreleaser build --parallelism 1 --auto-snapshot --clean {{ARGS}}
 
 # build the binary with tls enabled (default)
 build *ARGS='':
-    WITH_TLS=true just _build
+    WITH_TLS=true just _release
 
-# build the binary without tls enabled
-build-notls:
-    WITH_TLS=false just PACKAGE_NAME="{{PACKAGE_NAME}}-notls" _build
+build-target TARGET *ARGS='':
+    TARGET={{TARGET}} just _build --single-target
 
 # build using native zig command (to help with debugging)
 build-native *ARGS='':


### PR DESCRIPTION
Build for more mosquitto versions and cleanup some of the build tasks, and dependencies.

* build new versions
    * 2.0.11
    * 2.1.x-master (lastet on the master branch)
* use fixed openssl dependency on a specific commit to avoid breaking changes introduced by ziglang 0.16